### PR TITLE
Move JSON formatters to core

### DIFF
--- a/libextract/__init__.py
+++ b/libextract/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:

--- a/libextract/formatters.py
+++ b/libextract/formatters.py
@@ -11,10 +11,13 @@ def node_json(node, depth=0):
     return json
 
 
-def tabular_json(node_counter_pairs):
+def tabular_json(node_counter_pairs, **opts):
     rv = []
     for node, counter in node_counter_pairs:
         json = node_json(node)
-        json['contains'] = {e.tag: count for e, count in counter}
+        hits = json['contains'] = {}
+        for elem, count in counter:
+            hits[elem.tag] = child = node_json(elem, **opts)
+            child['count'] = count
         rv.append(json)
     return rv

--- a/libextract/formatters.py
+++ b/libextract/formatters.py
@@ -1,3 +1,6 @@
+UNLIMITED = float('NaN')
+
+
 def node_json(node, depth=0):
     json = {
         'xpath': node.getroottree().getpath(node),

--- a/libextract/formatters.py
+++ b/libextract/formatters.py
@@ -1,0 +1,20 @@
+def node_json(node, depth=0):
+    json = {
+        'xpath': node.getroottree().getpath(node),
+        'class': node.get('class'),
+        'text': node.text,
+        'tag': node.tag,
+        'id': node.get('id'),
+    }
+    if depth:
+        json['children'] = [node_json(n, depth-1) for n in node]
+    return json
+
+
+def tabular_json(node_counter_pairs):
+    rv = []
+    for node, counter in node_counter_pairs:
+        json = node_json(node)
+        json['contains'] = {e.tag: count for e, count in counter}
+        rv.append(json)
+    return rv

--- a/libextract/formatters.py
+++ b/libextract/formatters.py
@@ -1,10 +1,10 @@
 def node_json(node, depth=0):
     json = {
         'xpath': node.getroottree().getpath(node),
-        'class': node.get('class'),
+        'class': node.get('class', '').split(),
         'text': node.text,
         'tag': node.tag,
-        'id': node.get('id'),
+        'id': node.get('id', '').split(),
     }
     if depth:
         json['children'] = [node_json(n, depth-1) for n in node]

--- a/libextract/strategies.py
+++ b/libextract/strategies.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 # TODO: circular dependencies?
 from libextract.html.tabular import STRATEGY as TABULAR
 from libextract.html.article import STRATEGY, get_text

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+from lxml import etree
+from tests import asset_path
+from libextract.formatters import node_json, tabular_json
+
+
+FOOS_FILENAME = asset_path('full_of_foos.html')
+
+
+class TestNodeJson(TestCase):
+    def setUp(self):
+        self.etree = etree.fromstring(
+            '<html class="this those" id="that"><p>Hello World</p></html>'
+            )
+
+    def test_simple(self):
+        assert node_json(self.etree) == {
+            'xpath': '/html',
+            'class': ['this', 'those'],
+            'text': None,
+            'tag': 'html',
+            'id': ['that'],
+        }
+
+    def test_depth(self):
+        assert node_json(self.etree, depth=1) == {
+            'xpath': '/html',
+            'text': None,
+            'class': ['this', 'those'],
+            'id': ['that'],
+            'tag': 'html',
+            'children': [{
+                'xpath': '/html/p',
+                'text': 'Hello World',
+                'class': [],
+                'id': [],
+                'tag': 'p',
+            }]
+        }


### PR DESCRIPTION
Given the extremely tight coupling between the return values and the formatter used in libextract, I think that we should move all formatters to the core libextract library. Another option is that we start working on moving them to another repo once we have stabilised the API's return values rather than separating them from early on (easier to add a package to PyPI than remove it, so to speak). The new formatters are really easy to use:

```python
>>> from libextract import extract
>>> from libextract.formatters import node_json
>>> node_json(extract('<p>Hello World</p>', strategy=ARTICLE_NODE), depth=10)
{'children': [{'children': [],
               'class': None,
               'id': None,
               'tag': 'p',
               'text': 'Hello World',
               'xpath': '/html/body/p'}],
 'class': None,
 'id': None,
 'tag': 'body',
 'text': None,
 'xpath': '/html/body'}
```

And the pretty printed dictionary looks beautiful as well ;) With that being said making an XML formatter shouldn't be much of a hassle as we can simply pass the result of the ``node_json`` function to another function. Should we add them to core?

cc @rodricios 