### PR TITLE
Quantifiers

### DIFF
--- a/libextract/coretools.py
+++ b/libextract/coretools.py
@@ -20,12 +20,7 @@ def above_threshold(score):
     return proc
 
 
-def pipeline(data, *args):
-    try:
-        for arg in args[0:]:
-            data = arg(data)
-    except(TypeError):
-        for arg in args[0]:
-            data = arg(data)
-    finally:
-        return data
+def pipeline(data, functions):
+    for item in functions:
+        data = item(data)
+    return data

--- a/libextract/coretools.py
+++ b/libextract/coretools.py
@@ -20,7 +20,12 @@ def above_threshold(score):
     return proc
 
 
-def pipeline(data, functions):
-    for item in functions:
-        data = item(data)
-    return data
+def pipeline(data, *args):
+    try:
+        for arg in args[0:]:
+            data = arg(data)
+    except(TypeError):
+        for arg in args[0]:
+            data = arg(data)
+    finally:
+        return data

--- a/libextract/html/article.py
+++ b/libextract/html/article.py
@@ -2,16 +2,7 @@ from operator import itemgetter
 from libextract.html import parse_html
 from libextract.coretools import histogram, argmax
 from libextract.html._xpaths import NODES_WITH_TEXT, FILTER_TEXT
-
-
-def node_text_length(node):
-    """
-    Returns the length of the text contained within
-    a given *node*.
-    """
-    text = node.text
-    return len(' '.join(text.split())) if text else 0
-
+from libextract.quantifiers import text_length
 
 def get_node_length_pairs(etree):
     """
@@ -19,8 +10,7 @@ def get_node_length_pairs(etree):
     to node text length pairs.
     """
     for node in etree.xpath(NODES_WITH_TEXT):
-        yield node.getparent(), node_text_length(node)
-
+        yield node.getparent(), text_length(node)
 
 get_node = itemgetter(0)
 

--- a/libextract/html/tabular.py
+++ b/libextract/html/tabular.py
@@ -2,7 +2,7 @@ from operator import itemgetter
 from heapq import nlargest
 from libextract.html import parse_html
 from libextract.html._xpaths import SELECT_ALL
-from libextract.quantifiers import children_counter
+from libextract.quantifiers import count_children
 
 # TODO: Consolidate get_pairs functions
 # TODO: Converge on get_*, filter_*
@@ -16,7 +16,7 @@ def get_node_counter_pairs(etree):
     """
     for node in etree.xpath(SELECT_ALL):
         if len(node):
-            yield node, children_counter(node)
+            yield node, count_children(node)
 
 
 def node_counter_argmax(pairs):

--- a/libextract/html/tabular.py
+++ b/libextract/html/tabular.py
@@ -1,6 +1,5 @@
 from operator import itemgetter
 from heapq import nlargest
-from libextract.coretools import Counter
 from libextract.html import parse_html
 from libextract.html._xpaths import SELECT_ALL
 from libextract.quantifiers import children_counter

--- a/libextract/html/tabular.py
+++ b/libextract/html/tabular.py
@@ -3,19 +3,11 @@ from heapq import nlargest
 from libextract.coretools import Counter
 from libextract.html import parse_html
 from libextract.html._xpaths import SELECT_ALL
+from libextract.quantifiers import children_counter
 
 # TODO: Consolidate get_pairs functions
 # TODO: Converge on get_*, filter_*
 # TODO: Better yet, decide on "meta/pipelining language"
-
-
-def children_counter(node):
-    """
-    Returns the a collections.Counter object measuring the
-    frequenies of the children nodes (by tag name) contained
-    within a given *node*.
-    """
-    return Counter([child.tag for child in node])
 
 
 def get_node_counter_pairs(etree):

--- a/libextract/quantifiers.py
+++ b/libextract/quantifiers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 """
 A submodule providing 'quantifying' functions.
 
@@ -7,7 +8,8 @@ the function will return either a numerical type or a Counter
 where the key=<node> and value=<numerical>
 """
 
-from coretools import Counter
+from libextract.coretools import Counter
+
 
 def text_length(node):
     """

--- a/libextract/quantifiers.py
+++ b/libextract/quantifiers.py
@@ -20,7 +20,7 @@ def text_length(node):
     return len(' '.join(text.split())) if text else 0
 
 
-def children_counter(node):
+def count_children(node):
     """
     Returns the a collections.Counter object measuring the
     frequenies of the children nodes (by tag name) contained

--- a/libextract/quantifiers.py
+++ b/libextract/quantifiers.py
@@ -1,0 +1,27 @@
+"""
+A submodule providing 'quantifying' functions.
+
+The protocol that's followed is each function expects a "node"
+of type lxml.html.HtmlElement (sometimes *._ElementTree), and
+the function will return either a numerical type or a Counter
+where the key=<node> and value=<numerical>
+"""
+
+from coretools import Counter
+
+def text_length(node):
+    """
+    Returns the length of the text contained within
+    a given *node*.
+    """
+    text = node.text
+    return len(' '.join(text.split())) if text else 0
+
+
+def children_counter(node):
+    """
+    Returns the a collections.Counter object measuring the
+    frequenies of the children nodes (by tag name) contained
+    within a given *node*.
+    """
+    return Counter([child.tag for child in node])

--- a/libextract/quantifiers.py
+++ b/libextract/quantifiers.py
@@ -8,7 +8,7 @@ the function will return either a numerical type or a Counter
 where the key=<node> and value=<numerical>
 """
 
-from libextract.coretools import Counter
+from collections import Counter
 
 
 def text_length(node):

--- a/tests/html/test_article.py
+++ b/tests/html/test_article.py
@@ -1,11 +1,4 @@
-from libextract.html.article import get_node_length_pairs, node_text_length
-
-
-def test_node_text_length(etree):
-    res = etree.xpath('//body/article/div')
-    for node in res:
-        assert node_text_length(node) == 4
-    assert res
+from libextract.html.article import get_node_length_pairs
 
 
 def test_get_node_length_pairs(etree):

--- a/tests/html/test_tabular.py
+++ b/tests/html/test_tabular.py
@@ -1,8 +1,8 @@
 from pytest import fixture
 from lxml import etree
-from libextract.html.tabular import children_counter, \
-        get_node_counter_pairs, node_counter_argmax, \
-        sort_best_pairs, weighted_score, filter_tags
+from libextract.html.tabular import get_node_counter_pairs, \
+        node_counter_argmax, sort_best_pairs, weighted_score, \
+        filter_tags
 
 
 @fixture
@@ -19,14 +19,6 @@ def article(etree):
 def sorted_pairs(pairs):
     return sort_best_pairs(node_counter_argmax(pairs),
                            top=1)
-
-
-def test_children_counter(etree):
-    article = etree.xpath('//body/article')[0]
-    counter = children_counter(article)
-
-    assert len(counter) == 1
-    assert counter['div'] == 9
 
 
 def test_get_node_counter_pairs(pairs):

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -1,0 +1,15 @@
+from libextract.quantifiers import text_length, children_counter
+
+
+def test_text_length(etree):
+    res = etree.xpath('//body/article/div')
+    for node in res:
+        assert text_length(node) == 4
+    assert res
+
+def test_children_counter(etree):
+    article = etree.xpath('//body/article')[0]
+    counter = children_counter(article)
+
+    assert len(counter) == 1
+    assert counter['div'] == 9

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -7,7 +7,7 @@ def test_text_length(etree):
         assert text_length(node) == 4
     assert res
 
-def test_children_counter(etree):
+def test_count_children(etree):
     article = etree.xpath('//body/article')[0]
     counter = count_children(article)
 

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -1,4 +1,4 @@
-from libextract.quantifiers import text_length, children_counter
+from libextract.quantifiers import text_length, count_children
 
 
 def test_text_length(etree):
@@ -9,7 +9,7 @@ def test_text_length(etree):
 
 def test_children_counter(etree):
     article = etree.xpath('//body/article')[0]
-    counter = children_counter(article)
+    counter = count_children(article)
 
     assert len(counter) == 1
     assert counter['div'] == 9


### PR DESCRIPTION
Moving ``node_text_length`` and ``children_counter`` to their own submodule will hopefully do two things: 

1. Standardize - protocol is simple: 
  * input: *node* (``lxml.html.HtmlElement`` and sometimes ``*._ElementTree``) 
  * output: *quantity* or *quantities* (``numerical`` or ``collections.Counter``)

2. Modularize - the bigger goal of creating a truly functional lib is still pretty unclear, but this branch will hopefully simplify a user's experience in creating custom pipelines:

Consider:
```python
from libextract.html.tabular import children_counter
from libextract.html.article import node_text_length
```
vs. 
```python
from libextract.quantifiers import children_counter, text_length
```
Partially addresses issue #1 